### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,12 +45,12 @@ module.exports = function (config, env) {
 
     sassRule.test = /\.s[ac]ss$/
     sassRule.exclude = /\.module\.s[ac]ss$/
-    addAfterRule(sassRule, postcssLoaderMatcher, require.resolve('sass-loader'))
+    addAfterRule(sassRule, postcssLoaderMatcher, { loader: require.resolve('sass-loader') })
     addBeforeRule(config.module.rules, fileLoaderMatcher, sassRule)
 
     const sassModulesRule = cloneDeep(cssModulesRule)
     sassModulesRule.test = /\.module\.s[ac]ss$/
-    addAfterRule(sassModulesRule, postcssLoaderMatcher, require.resolve('sass-loader'))
+    addAfterRule(sassModulesRule, postcssLoaderMatcher, { loader: require.resolve('sass-loader') })
     addBeforeRule(config.module.rules, fileLoaderMatcher, sassModulesRule)
 
     return config


### PR DESCRIPTION
I want to modify the sass-loader in another "rewire" and I would like to use your createLoaderMatcher to find that sass-loader. Would be great if the sass-loader follows the same convention as the other loaders `{ "loader": "../sass-loader/"}`.